### PR TITLE
Delete focused task with Key X if the task is placed on Done pane 

### DIFF
--- a/cmd/hashira-cui/view.go
+++ b/cmd/hashira-cui/view.go
@@ -264,14 +264,22 @@ func (v *View) setPriorityLow(priorities []*service.Priority, task *service.Task
 
 func (v *View) KeyX(*gocui.Gui, *gocui.View) error {
 	t := v.FocusedTask()
-	return v.moveTaskToDone(t)
+	return v.markTaskAsDone(t)
 }
 
-func (v *View) moveTaskToDone(t *service.Task) error {
+// markTaskAsDone moves specified task to Done pane.
+// If the specified task is already on Done, the task is deleted.
+func (v *View) markTaskAsDone(t *service.Task) error {
 	p := v.panes[pn[len(pn)-1]] // last pane (may be Done)
 	if t == nil || p == nil {
 		return nil
 	}
+
+	if t.Place == p.place {
+		t.IsDeleted = true
+		return v.Delegate("update", t)
+	}
+
 	return v.moveTaskPlaceTo(t, p, 0)
 }
 


### PR DESCRIPTION
Currently there's no way to delete registered tasks.
This PR provides functionality to delete a task with following manners.
* Move task to Done pane (with key X or select and move).
* Focus a task on Done pane and press key X.

Note that currently there's no way to undo the deletion.