### PR TITLE
[#49] Update keybinding while editing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 run:
   skip-dirs:
     - cmd/hashira-gui
+
 linters:
   enable-all: true
 

--- a/cmd/hashira-cui/editor.go
+++ b/cmd/hashira-cui/editor.go
@@ -10,10 +10,22 @@ var HashiraEditor = &Editor{}
 
 func (e *Editor) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) {
 	switch key {
-	case gocui.KeyCtrlH:
+	case gocui.KeyCtrlF:
 		v.MoveCursor(+1, 0, false)
-	case gocui.KeyCtrlL:
+	case gocui.KeyCtrlB:
 		v.MoveCursor(-1, 0, false)
+	case gocui.KeyCtrlA:
+		// move to start of line
+		maxX, _ := v.Size()
+		v.MoveCursor(-maxX, 0, false)
+	case gocui.KeyCtrlE:
+		// move to end of line
+		bufLen := len(v.Buffer())
+		cx, _ := v.Cursor()
+		v.MoveCursor(+bufLen-cx-1, 0, false)
+	case gocui.KeyCtrlD:
+		v.EditDelete(false)
+	default:
+		gocui.DefaultEditor.Edit(v, key, ch, mod)
 	}
-	gocui.DefaultEditor.Edit(v, key, ch, mod)
 }

--- a/cmd/hashira-cui/editor.go
+++ b/cmd/hashira-cui/editor.go
@@ -4,11 +4,11 @@ import (
 	"github.com/jroimartin/gocui"
 )
 
-type Editor struct{}
+type editor struct{}
 
-var HashiraEditor = &Editor{}
+var hashiraEditor = &editor{}
 
-func (e *Editor) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) {
+func (e *editor) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) {
 	switch key {
 	case gocui.KeyCtrlF:
 		v.MoveCursor(+1, 0, false)

--- a/cmd/hashira-cui/editor.go
+++ b/cmd/hashira-cui/editor.go
@@ -1,11 +1,19 @@
 package main
 
-import "github.com/jroimartin/gocui"
+import (
+	"github.com/jroimartin/gocui"
+)
 
 type Editor struct{}
 
 var HashiraEditor = &Editor{}
 
 func (e *Editor) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) {
+	switch key {
+	case gocui.KeyCtrlH:
+		v.MoveCursor(+1, 0, false)
+	case gocui.KeyCtrlL:
+		v.MoveCursor(-1, 0, false)
+	}
 	gocui.DefaultEditor.Edit(v, key, ch, mod)
 }

--- a/cmd/hashira-cui/editor.go
+++ b/cmd/hashira-cui/editor.go
@@ -1,0 +1,11 @@
+package main
+
+import "github.com/jroimartin/gocui"
+
+type Editor struct{}
+
+var HashiraEditor = &Editor{}
+
+func (e *Editor) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) {
+	gocui.DefaultEditor.Edit(v, key, ch, mod)
+}

--- a/cmd/hashira-cui/keybinding.go
+++ b/cmd/hashira-cui/keybinding.go
@@ -98,23 +98,3 @@ func (v *View) KeySpace(g *gocui.Gui, gv *gocui.View) error {
 func (v *View) KeyEnter(g *gocui.Gui, gv *gocui.View) error {
 	return v.input(g, gv)
 }
-
-// KeyCtrlH reacts when Ctrl-h is pressed while inputting task
-// TODO:
-// keybindings for input should inject Editor interface
-func (v *View) KeyCtrlH(g *gocui.Gui, gv *gocui.View) error {
-	gv.MoveCursor(-1, 0, true)
-	return nil
-}
-
-// KeyCtrlL reacts when Ctrl-l is pressed while inputting task
-// TODO:
-// keybindings for input should inject Editor interface
-func (v *View) KeyCtrlL(g *gocui.Gui, gv *gocui.View) error {
-	x, _ := gv.Cursor()
-	if len(gv.Buffer())-1 <= x {
-		return nil
-	}
-	gv.MoveCursor(+1, 0, true)
-	return nil
-}

--- a/cmd/hashira-cui/view.go
+++ b/cmd/hashira-cui/view.go
@@ -338,16 +338,6 @@ func (v *View) showInput(g *gocui.Gui) error {
 		input.Editable = true
 		input.Editor = HashiraEditor
 		input.MoveCursor(len(input.Buffer())-1, 0, true)
-		/*
-			err = g.SetKeybinding(input.Name(), gocui.KeyCtrlH, gocui.ModNone, v.KeyCtrlH)
-			if err != nil {
-				log.Printf("[ERROR] %v", err)
-			}
-			err = g.SetKeybinding(input.Name(), gocui.KeyCtrlL, gocui.ModNone, v.KeyCtrlL)
-			if err != nil {
-				log.Printf("[ERROR] %v", err)
-			}
-		*/
 		g.Cursor = true
 	}
 

--- a/cmd/hashira-cui/view.go
+++ b/cmd/hashira-cui/view.go
@@ -336,16 +336,18 @@ func (v *View) showInput(g *gocui.Gui) error {
 			}
 		}
 		input.Editable = true
+		input.Editor = HashiraEditor
 		input.MoveCursor(len(input.Buffer())-1, 0, true)
-		// TODO: should inject Editor interface
-		err = g.SetKeybinding(input.Name(), gocui.KeyCtrlH, gocui.ModNone, v.KeyCtrlH)
-		if err != nil {
-			log.Printf("[ERROR] %v", err)
-		}
-		err = g.SetKeybinding(input.Name(), gocui.KeyCtrlL, gocui.ModNone, v.KeyCtrlL)
-		if err != nil {
-			log.Printf("[ERROR] %v", err)
-		}
+		/*
+			err = g.SetKeybinding(input.Name(), gocui.KeyCtrlH, gocui.ModNone, v.KeyCtrlH)
+			if err != nil {
+				log.Printf("[ERROR] %v", err)
+			}
+			err = g.SetKeybinding(input.Name(), gocui.KeyCtrlL, gocui.ModNone, v.KeyCtrlL)
+			if err != nil {
+				log.Printf("[ERROR] %v", err)
+			}
+		*/
 		g.Cursor = true
 	}
 

--- a/cmd/hashira-cui/view.go
+++ b/cmd/hashira-cui/view.go
@@ -336,7 +336,7 @@ func (v *View) showInput(g *gocui.Gui) error {
 			}
 		}
 		input.Editable = true
-		input.Editor = HashiraEditor
+		input.Editor = hashiraEditor
 		input.MoveCursor(len(input.Buffer())-1, 0, true)
 		g.Cursor = true
 	}


### PR DESCRIPTION
## Pull request for issue #49 

## Updates

Keybindings while editing have been updated as follows:
- C-f to move cursor forward (without editing)
- C-b to move cursor backword (without editing)
- C-a to move cursor on start of line
- C-e to move cursor on end of line
- C-d to delete a character on cursor
- C-h is now same as Backspace (delete and move cursor -1)