### PR TITLE
[#69] fix backspace while editing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -148,13 +148,13 @@
   revision = "1e272ff78dcb4c448870f464fda1cdcf2bf0b3dd"
 
 [[projects]]
-  branch = "master"
-  digest = "1:d566efc42265654f2609832766ba928e0a2bc5095f782f98616b405690392abc"
+  branch = "backspace_for_widecharactor"
+  digest = "1:1a8e1b97647dc6929b6692959c5965d0e70a758de417c54a97aba81662efdd98"
   name = "github.com/jroimartin/gocui"
   packages = ["."]
   pruneopts = "UT"
-  revision = "fe55a32c8a4c7cf94b04a6507eae7ece48c2f975"
-  source = "https://github.com/jesseduffield/gocui"
+  revision = "f7455dd8def167a6908454341a37d2d81aeb7217"
+  source = "https://github.com/pankona/gocui"
 
 [[projects]]
   digest = "1:f97285a3b0a496dcf8801072622230d513f69175665d94de60eb042d03387f6c"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -43,8 +43,8 @@
 
 [[constraint]]
   name = "github.com/jroimartin/gocui"
-  source = "https://github.com/jesseduffield/gocui"
-  branch = "master"
+  source = "https://github.com/pankona/gocui"
+  branch = "backspace_for_widecharactor"
 
 [[constraint]]
   branch = "master"

--- a/go.mod
+++ b/go.mod
@@ -35,4 +35,4 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 
-replace github.com/jroimartin/gocui v0.4.0 => github.com/jesseduffield/gocui v0.3.1-0.20181209104758-fe55a32c8a4c
+replace github.com/jroimartin/gocui v0.4.0 => github.com/pankona/gocui v0.3.1-0.20181214002935-f7455dd8def1

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
-github.com/jesseduffield/gocui v0.3.1-0.20181209104758-fe55a32c8a4c h1:wFWwsZwBI/Jri8hrHjmd+IF6D+zeziZtWU53Ota16qE=
-github.com/jesseduffield/gocui v0.3.1-0.20181209104758-fe55a32c8a4c/go.mod h1:2RtZznzYKt8RLRwvFiSkXjU0Ei8WwHdubgnlaYH47dw=
 github.com/jesseduffield/termbox-go v0.0.0-20180919093808-1e272ff78dcb h1:cFHYEWpQEfzFZVKiKZytCUX4UwQixKSw0kd3WhluPsY=
 github.com/jesseduffield/termbox-go v0.0.0-20180919093808-1e272ff78dcb/go.mod h1:anMibpZtqNxjDbxrcDEAwSdaJ37vyUeM1f/M4uekib4=
 github.com/jroimartin/gocui v0.4.0 h1:52jnalstgmc25FmtGcWqa0tcbMEWS6RpFLsOIO+I+E8=
@@ -52,6 +50,8 @@ github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8Bz
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
+github.com/pankona/gocui v0.3.1-0.20181214002935-f7455dd8def1 h1:APmgm2lBHzCD2ShOwazrbMgoRCaxD7JPwMwNoNIMvJk=
+github.com/pankona/gocui v0.3.1-0.20181214002935-f7455dd8def1/go.mod h1:YbpnnaXew8rp90mxIrWZhP7FNJoXGaiChttkzIiVRB0=
 github.com/pankona/orderedmap v0.0.0-20181010071912-782e514ec868 h1:PctvejLvtIhVvQqxqJZkO2TTkDg1gGe6XOt0p8q8KFE=
 github.com/pankona/orderedmap v0.0.0-20181010071912-782e514ec868/go.mod h1:ydQRa986pZuWSGcbkiLzrF2N6KBbKDOlyunsQKsXdfQ=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=


### PR DESCRIPTION
## Pull request for #69 

## Updates
- use pankona/gocui instead of jesseduffield/gocui temporarily.
  - fix an issue: backspace sometimes doesn't work if the line includes wide charactor.