### PR TITLE
support "go get" to install latest hashira-cui

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -140,15 +140,6 @@
   version = "v2.0.2"
 
 [[projects]]
-  branch = "insert_for_widecharactor"
-  digest = "1:c5174c9ef95be1d636223e7253e197ffa481996084261810cc98249161cffae9"
-  name = "github.com/jesseduffield/gocui"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "d48855abd71f2815d60720cc04deda7797d63d1f"
-  source = "https://github.com/pankona/gocui"
-
-[[projects]]
   branch = "master"
   digest = "1:5de83c7993750a8b065540cb6a44040c41fd166ce9a29ae030104951ade80f40"
   name = "github.com/jesseduffield/termbox-go"
@@ -195,6 +186,14 @@
   pruneopts = "UT"
   revision = "ce7b0b5c7b45a81508558cd1dba6bb1e4ddb51bb"
   version = "v0.0.3"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c5174c9ef95be1d636223e7253e197ffa481996084261810cc98249161cffae9"
+  name = "github.com/pankona/gocui"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b2c49721076e2a11357afb11825406ee5cb05739"
 
 [[projects]]
   branch = "master"
@@ -444,8 +443,8 @@
     "github.com/asticode/go-astilectron-bundler",
     "github.com/etcd-io/bbolt",
     "github.com/golang/protobuf/proto",
-    "github.com/jesseduffield/gocui",
     "github.com/mattn/go-runewidth",
+    "github.com/pankona/gocui",
     "github.com/pankona/orderedmap",
     "github.com/pkg/errors",
     "github.com/stretchr/testify/require",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -140,21 +140,21 @@
   version = "v2.0.2"
 
 [[projects]]
+  branch = "insert_for_widecharactor"
+  digest = "1:c5174c9ef95be1d636223e7253e197ffa481996084261810cc98249161cffae9"
+  name = "github.com/jesseduffield/gocui"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d48855abd71f2815d60720cc04deda7797d63d1f"
+  source = "https://github.com/pankona/gocui"
+
+[[projects]]
   branch = "master"
   digest = "1:5de83c7993750a8b065540cb6a44040c41fd166ce9a29ae030104951ade80f40"
   name = "github.com/jesseduffield/termbox-go"
   packages = ["."]
   pruneopts = "UT"
   revision = "1e272ff78dcb4c448870f464fda1cdcf2bf0b3dd"
-
-[[projects]]
-  branch = "insert_for_widecharactor"
-  digest = "1:c5174c9ef95be1d636223e7253e197ffa481996084261810cc98249161cffae9"
-  name = "github.com/jroimartin/gocui"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "d48855abd71f2815d60720cc04deda7797d63d1f"
-  source = "https://github.com/pankona/gocui"
 
 [[projects]]
   digest = "1:f97285a3b0a496dcf8801072622230d513f69175665d94de60eb042d03387f6c"
@@ -302,14 +302,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c73348dab344986c67ff12db47eee08aa2ec1f6bf431dcd73514c6dd8c502a57"
+  digest = "1:ba8cbf57cfd92d5f8592b4aca1a35d92c162363d32aeabd5b12555f8896635e7"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "7da8ea5c81829e397bdf930c5d8ba4b703616f33"
+  revision = "4d1cda033e0619309c606fc686de3adcf599539e"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -347,7 +347,7 @@
     "transport/grpc",
   ]
   pruneopts = "UT"
-  revision = "40e757e92c52ce056bea83c8050054d41443ade8"
+  revision = "874d9dc5b186e361475b082852f136f094555c30"
 
 [[projects]]
   digest = "1:b13819327be647014031c6a194299da87ca35313bfc01fdc1da7bd3ddf08cbce"
@@ -444,7 +444,7 @@
     "github.com/asticode/go-astilectron-bundler",
     "github.com/etcd-io/bbolt",
     "github.com/golang/protobuf/proto",
-    "github.com/jroimartin/gocui",
+    "github.com/jesseduffield/gocui",
     "github.com/mattn/go-runewidth",
     "github.com/pankona/orderedmap",
     "github.com/pkg/errors",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,7 +42,7 @@
   version = "1.2.0"
 
 [[constraint]]
-  name = "github.com/jroimartin/gocui"
+  name = "github.com/jesseduffield/gocui"
   source = "https://github.com/pankona/gocui"
   branch = "insert_for_widecharactor"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,9 +42,8 @@
   version = "1.2.0"
 
 [[constraint]]
-  name = "github.com/jesseduffield/gocui"
-  source = "https://github.com/pankona/gocui"
-  branch = "insert_for_widecharactor"
+  name = "github.com/pankona/gocui"
+  branch = "master"
 
 [[constraint]]
   branch = "master"

--- a/cmd/hashira-cui/editor.go
+++ b/cmd/hashira-cui/editor.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/jesseduffield/gocui"
+	"github.com/pankona/gocui"
 )
 
 type editor struct{}

--- a/cmd/hashira-cui/keybinding.go
+++ b/cmd/hashira-cui/keybinding.go
@@ -3,9 +3,8 @@ package main
 import (
 	"log"
 
+	"github.com/pankona/gocui"
 	"github.com/pkg/errors"
-
-	"github.com/jesseduffield/gocui"
 )
 
 type errContainer struct {

--- a/cmd/hashira-cui/main.go
+++ b/cmd/hashira-cui/main.go
@@ -10,7 +10,7 @@ import (
 	"os/user"
 	"path/filepath"
 
-	"github.com/jesseduffield/gocui"
+	"github.com/pankona/gocui"
 	hashirac "github.com/pankona/hashira/client"
 	"github.com/pankona/hashira/daemon"
 	"github.com/pankona/hashira/database"

--- a/cmd/hashira-cui/pane.go
+++ b/cmd/hashira-cui/pane.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/jesseduffield/gocui"
+	"github.com/pankona/gocui"
 	"github.com/pankona/hashira/service"
 	"github.com/pankona/orderedmap"
 )

--- a/cmd/hashira-cui/view.go
+++ b/cmd/hashira-cui/view.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/jesseduffield/gocui"
 	runewidth "github.com/mattn/go-runewidth"
+	"github.com/pankona/gocui"
 	"github.com/pankona/hashira/service"
 	"github.com/pankona/orderedmap"
 )

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/etcd-io/bbolt v1.3.0
 	github.com/golang/protobuf v1.2.0
 	github.com/googleapis/gax-go v2.0.2+incompatible // indirect
+	github.com/jesseduffield/gocui v0.3.1
 	github.com/jesseduffield/termbox-go v0.0.0-20180919093808-1e272ff78dcb // indirect
-	github.com/jroimartin/gocui v0.4.0
 	github.com/julienschmidt/httprouter v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
@@ -35,4 +35,4 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 
-replace github.com/jroimartin/gocui v0.4.0 => github.com/pankona/gocui v0.3.1-0.20181214061939-d48855abd71f
+replace github.com/jesseduffield/gocui v0.3.1 => github.com/pankona/gocui v0.3.1-0.20181214061939-d48855abd71f

--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,12 @@ require (
 	github.com/etcd-io/bbolt v1.3.0
 	github.com/golang/protobuf v1.2.0
 	github.com/googleapis/gax-go v2.0.2+incompatible // indirect
-	github.com/jesseduffield/gocui v0.3.1
 	github.com/jesseduffield/termbox-go v0.0.0-20180919093808-1e272ff78dcb // indirect
 	github.com/julienschmidt/httprouter v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/mattn/go-runewidth v0.0.3
+	github.com/pankona/gocui v0.3.1-0.20181214144533-b2c49721076e
 	github.com/pankona/orderedmap v0.0.0-20181010071912-782e514ec868
 	github.com/pkg/errors v0.8.0
 	github.com/sirupsen/logrus v1.2.0 // indirect
@@ -34,5 +34,3 @@ require (
 	google.golang.org/grpc v1.14.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
-
-replace github.com/jesseduffield/gocui v0.3.1 => github.com/pankona/gocui v0.3.1-0.20181214061939-d48855abd71f

--- a/go.sum
+++ b/go.sum
@@ -48,7 +48,8 @@ github.com/mattn/go-runewidth v0.0.3 h1:a+kO+98RDGEfo6asOGMmpodZq4FNtnGP54yps8Bz
 github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
-github.com/pankona/gocui v0.3.1-0.20181214061939-d48855abd71f/go.mod h1:YbpnnaXew8rp90mxIrWZhP7FNJoXGaiChttkzIiVRB0=
+github.com/pankona/gocui v0.3.1-0.20181214144533-b2c49721076e h1:3UBUrJGU+mKPFkykog1Q7Zmuunjfk/scN2VH/BAbSgI=
+github.com/pankona/gocui v0.3.1-0.20181214144533-b2c49721076e/go.mod h1:YbpnnaXew8rp90mxIrWZhP7FNJoXGaiChttkzIiVRB0=
 github.com/pankona/orderedmap v0.0.0-20181010071912-782e514ec868 h1:PctvejLvtIhVvQqxqJZkO2TTkDg1gGe6XOt0p8q8KFE=
 github.com/pankona/orderedmap v0.0.0-20181010071912-782e514ec868/go.mod h1:ydQRa986pZuWSGcbkiLzrF2N6KBbKDOlyunsQKsXdfQ=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/jesseduffield/termbox-go v0.0.0-20180919093808-1e272ff78dcb h1:cFHYEWpQEfzFZVKiKZytCUX4UwQixKSw0kd3WhluPsY=
 github.com/jesseduffield/termbox-go v0.0.0-20180919093808-1e272ff78dcb/go.mod h1:anMibpZtqNxjDbxrcDEAwSdaJ37vyUeM1f/M4uekib4=
-github.com/jroimartin/gocui v0.4.0 h1:52jnalstgmc25FmtGcWqa0tcbMEWS6RpFLsOIO+I+E8=
-github.com/jroimartin/gocui v0.4.0/go.mod h1:7i7bbj99OgFHzo7kB2zPb8pXLqMBSQegY7azfqXMkyY=
 github.com/julienschmidt/httprouter v1.2.0 h1:TDTW5Yz1mjftljbcKqRcrYhd4XeOoI98t+9HbQbYf7g=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=


### PR DESCRIPTION
## Updates

- change dependencies and import path to support install hashira-cui via go get 