### PR TITLE
Avoid overwrite if the task is dirty

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -95,8 +95,7 @@ func (c *Client) PhysicalDelete(ctx context.Context, id string) error {
 }
 
 // Retrieve retrieves all tasks
-func (c *Client) Retrieve(
-	ctx context.Context) (map[string]*service.Task, error) {
+func (c *Client) Retrieve(ctx context.Context) (map[string]*service.Task, error) {
 	var tasks map[string]*service.Task
 
 	err := c.withClient(
@@ -114,8 +113,7 @@ func (c *Client) Retrieve(
 }
 
 // Retrieve retrieves all tasks
-func (c *Client) RetrieveAll(
-	ctx context.Context) (map[string]*service.Task, error) {
+func (c *Client) RetrieveAll(ctx context.Context) (map[string]*service.Task, error) {
 	var tasks map[string]*service.Task
 
 	err := c.withClient(
@@ -133,9 +131,7 @@ func (c *Client) RetrieveAll(
 }
 
 // UpdatePriority updates tasks' priorities
-func (c *Client) UpdatePriority(
-	ctx context.Context,
-	priorities map[string]*service.Priority) (map[string]*service.Priority, error) {
+func (c *Client) UpdatePriority(ctx context.Context, priorities map[string]*service.Priority) (map[string]*service.Priority, error) {
 	var ret map[string]*service.Priority
 
 	err := c.withClient(func(hc service.HashiraClient) error {
@@ -154,8 +150,7 @@ func (c *Client) UpdatePriority(
 }
 
 // RetrievePriority retrieves tasks' priorities
-func (c *Client) RetrievePriority(
-	ctx context.Context) (map[string]*service.Priority, error) {
+func (c *Client) RetrievePriority(ctx context.Context) (map[string]*service.Priority, error) {
 	var ret map[string]*service.Priority
 
 	err := c.withClient(func(hc service.HashiraClient) error {

--- a/cmd/hashira-cui/main.go
+++ b/cmd/hashira-cui/main.go
@@ -90,7 +90,11 @@ func main() {
 			log.Printf("HASHIRA_ACCESSTOKEN is invalid. Synchronization is not started: %v", err)
 		}
 		m.SetAccessToken(accesstoken)
-		go m.SyncOnNotify(context.Background())
+		go func() {
+			if err := m.SyncOnNotify(context.Background()); err != nil {
+				log.Printf("sync on notify finished: %v", err)
+			}
+		}()
 	}
 
 	// prepare controller

--- a/cmd/hashira-cui/main.go
+++ b/cmd/hashira-cui/main.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
-	"time"
 
 	"github.com/pankona/gocui"
 	hashirac "github.com/pankona/hashira/client"
@@ -68,16 +67,6 @@ func main() {
 		d.Stop()
 	}()
 
-	// Start synchronization with cloud if HASHIRA_ACCESS_TOKEN is set
-	accesstoken, ok := os.LookupEnv("HASHIRA_ACCESS_TOKEN")
-	var isAccessTokenValid bool
-	if ok {
-		if err := startSync(context.Background(), daemonPort, accesstoken); err != nil {
-			log.Printf("failed to start synchronization: %v", err)
-		}
-		isAccessTokenValid = true
-	}
-
 	// initialize gocui
 	// specify false means: supportOverlaps = false
 	g, err := gocui.NewGui(gocui.OutputNormal, false)
@@ -90,8 +79,18 @@ func main() {
 	hashirac := &hashirac.Client{Address: fmt.Sprintf("localhost:%d", daemonPort)}
 	syncclient := &syncutil.Client{DaemonPort: daemonPort}
 	m := NewModel(hashirac, syncclient)
-	if isAccessTokenValid {
+
+	// Start synchronization with cloud if HASHIRA_ACCESS_TOKEN is set
+	accesstoken, ok := os.LookupEnv("HASHIRA_ACCESS_TOKEN")
+
+	if ok {
+		sc := syncutil.Client{DaemonPort: daemonPort}
+		err := sc.TestAccessToken(accesstoken)
+		if err != nil {
+			log.Printf("HASHIRA_ACCESSTOKEN is invalid. Synchronization is not started: %v", err)
+		}
 		m.SetAccessToken(accesstoken)
+		go m.SyncOnNotify(context.Background())
 	}
 
 	// prepare controller
@@ -125,36 +124,4 @@ func main() {
 	if err != nil && err != gocui.ErrQuit {
 		log.Panicln(err)
 	}
-}
-
-func startSync(ctx context.Context, daemonPort int, accesstoken string) error {
-	log.Printf("start synchronization...\n")
-
-	sc := syncutil.Client{DaemonPort: daemonPort}
-	err := sc.TestAccessToken(accesstoken)
-	if err != nil {
-		return fmt.Errorf("HASHIRA_ACCESSTOKEN is invalid. Synchronization is not started: %w", err)
-	}
-	log.Printf("HASHIRA_ACCESSTOKEN is valid. hashira-web will work!\n")
-
-	const syncInterval = 10 * time.Minute
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				break
-			default:
-				if err := sc.Upload(accesstoken, syncutil.UploadDirtyOnly); err != nil {
-					log.Printf("failed to upload: %v", err)
-				}
-				if err := sc.Download(accesstoken); err != nil {
-					log.Printf("failed to download: %v", err)
-				}
-				<-time.After(syncInterval)
-			}
-		}
-	}()
-
-	return nil
 }

--- a/cmd/hashira-cui/model.go
+++ b/cmd/hashira-cui/model.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -88,6 +89,8 @@ func (m *Model) NotifySync() {
 	}
 }
 
+var errSyncOnNotifyCanceled = errors.New("sync on notify has been canceled")
+
 func (m *Model) SyncOnNotify(ctx context.Context) error {
 	if m.accesstoken == "" {
 		return nil
@@ -98,7 +101,7 @@ func (m *Model) SyncOnNotify(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return errSyncOnNotifyCanceled
 		case <-m.syncChan:
 			if cancelFunc != nil {
 				cancelFunc()


### PR DESCRIPTION
## Pull request for issue #269

## Updates

- execute synchronization only when task or priority is dirty
  - 10 minutes polling is removed
- make tasks clean after upload is finished
- don't run download if there's dirty task
