### PR TITLE
Fix WebApp CI with dependency issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
   open-pull-requests-limit: 10
   labels:
   - automerge
+  ignore:
+    - dependency-name: '@types/node'
+      update-types: ['version-update:semver-major']
 - package-ecosystem: gomod
   directory: "/hashira-web/functions"
   schedule:

--- a/.github/workflows/hashira-web--test.yml
+++ b/.github/workflows/hashira-web--test.yml
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version-file: "hashira-web/.tool-versions"
           cache: "yarn"
           cache-dependency-path: "hashira-web/yarn.lock"
       - run: yarn install

--- a/hashira-web/.tool-versions
+++ b/hashira-web/.tool-versions
@@ -1,2 +1,2 @@
 yarn 1.22.15
-nodejs 16.11.0
+nodejs 16.20.0

--- a/hashira-web/package.json
+++ b/hashira-web/package.json
@@ -33,6 +33,7 @@
     "vite": "^4.2.0"
   },
   "dependencies": {
+    "@types/node": "^16.18.36",
     "firebase": "^9.22.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/hashira-web/yarn.lock
+++ b/hashira-web/yarn.lock
@@ -1174,6 +1174,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
   integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
 
+"@types/node@^16.18.36":
+  version "16.18.36"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.36.tgz#0db5d7efc4760d36d0d1d22c85d1a53accd5dc27"
+  integrity sha512-8egDX8dE50XyXWH6C6PRCNkTP106DuUrvdrednFouDSmCi7IOvrqr0frznfZaHifHH/3aq/7a7v9N4wdXMqhBQ==
+
 "@types/prop-types@*":
   version "15.7.4"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"


### PR DESCRIPTION
## Pull request for issue #{issue number}

Many dependabot PRs are failed from using old nodejs. See https://github.com/pankona/hashira/pull/827 as an example.

https://github.com/pankona/hashira/actions/runs/5258857960/jobs/9503647993#step:4:8

```
Run yarn install
yarn install v1.22.19
[1/[4](https://github.com/pankona/hashira/actions/runs/5258857960/jobs/9503647993#step:4:5)] Resolving packages...
[2/4] Fetching packages...
error firebase-tools@12.0.0: The engine "node" is incompatible with this module. Expected version ">=1[6](https://github.com/pankona/hashira/actions/runs/5258857960/jobs/9503647993#step:4:7).13.0 || >=1[8](https://github.com/pankona/hashira/actions/runs/5258857960/jobs/9503647993#step:4:9).0.0". Got "14.21.3"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

## Updates

Looks like the maintainer is using asdf or rtx because this repository has a [.tool-version file](https://github.com/pankona/hashira/blob/82a2db4cc62420c72c2aa6450dc5d640edd7cdc8/hashira-web/.tool-versions).
setup-node can parse it since v3

https://github.com/actions/setup-node/pull/373
https://github.com/actions/setup-node/commit/5b949b50c3461bbcd5a540b150c368278160234a

Using the same versions with CI should be better.

And we need to care https://github.com/microsoft/TypeScript/issues/51567
