### PR TITLE
Bump CI dependencies around golangci-lint

### DIFF
--- a/.github/workflows/hashira-cui--test.yml
+++ b/.github/workflows/hashira-cui--test.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
           go-version: '^1.19.1'
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.53.3
 


### PR DESCRIPTION
Fix golang layer CI 
It is the blocker for merging https://github.com/pankona/hashira/pull/833 and #836