### PR TITLE
release: Use the same version of go as specified in go.mod

### DIFF
--- a/.github/workflows/hashira-cui--release.yml
+++ b/.github/workflows/hashira-cui--release.yml
@@ -12,9 +12,10 @@ jobs:
         with:
           fetch-depth: 1
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.17
+          go-version-file: 'go.mod'
+          cache-dependency-path: 'go.sum'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:


### PR DESCRIPTION
Currently using old version for releasing than CI
