### PR TITLE
Bump go 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,4 +30,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.19
+go 1.20

--- a/hashira-web/functions/go.mod
+++ b/hashira-web/functions/go.mod
@@ -1,6 +1,6 @@
 module github.com/pankona/hashira/hashira-web/functions
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/firestore v1.10.0


### PR DESCRIPTION
We fixed CI that is in 🔴 longtime.

So we can update to latest golang if CI passed 🤔 
