### PR TITLE
Remove unused prettier dependency

### DIFF
--- a/hashira-web/package.json
+++ b/hashira-web/package.json
@@ -22,7 +22,6 @@
     "@vitejs/plugin-react": "^4.0.1",
     "ansi-regex": "6.0.1",
     "firebase-tools": "^12.4.0",
-    "prettier": "^2.8.8",
     "react-router-dom": "^6.13.0",
     "reload": "^3.2.1",
     "styled-components": "^5.3.11",

--- a/hashira-web/yarn.lock
+++ b/hashira-web/yarn.lock
@@ -4448,11 +4448,6 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^2.8.8:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
-
 printj@~1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"


### PR DESCRIPTION
prettier is installed but not used anywhere. Some files look formatted, but some are not. CI does not exist around them.

I want to use formatters (especially dprint). But just having a dependency is not useful.

@pankona Do you have any plans to integrate with them?