### PR TITLE
Prevent to add blank tasks in WebUI

### DIFF
--- a/hashira-web/src/TaskInput.tsx
+++ b/hashira-web/src/TaskInput.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import { StyledHorizontalSpacer } from "./styles";
+import { normalizeTasks } from "./task";
 
 const StyledInputForm = styled.form`
   display: flex;
@@ -26,7 +27,7 @@ const TaskInput: React.VFC<{
         type="submit"
         value="Submit"
         autoFocus={true}
-        disabled={tasks.length === 0 || disabled}
+        disabled={normalizeTasks(tasks).length === 0 || disabled}
         onClick={async (e: React.FormEvent<HTMLInputElement>) => {
           e.preventDefault();
           await onSubmitTasks(tasks);

--- a/hashira-web/src/hooks.ts
+++ b/hashira-web/src/hooks.ts
@@ -1,6 +1,7 @@
 import React from "react";
 import * as firebase from "./firebase";
 import { tasksAndPrioritiesInitialValue } from "./firebase";
+import { normalizeTasks } from "./task";
 
 type APIState<T> = {
   isLoading: boolean;
@@ -29,7 +30,7 @@ export const useAddTasks = (): [
         });
 
         firebase
-          .uploadTasks(tasksToAdd)
+          .uploadTasks(normalizeTasks(tasksToAdd))
           .then(() => {
             setState({
               isLoading: false,

--- a/hashira-web/src/task.ts
+++ b/hashira-web/src/task.ts
@@ -1,0 +1,6 @@
+export const normalizeTasks = (lines: readonly string[]): string[] => {
+  return lines.flatMap((line) => {
+    const task = line.trim();
+    return task ? [task] : [];
+  });
+};


### PR DESCRIPTION
Currently it looks like all inputs are submitted and saved.
I think rejecting duplicate tasks is a backend task. But just checking and preventing spaces will improve the frontend experience.