### PR TITLE
Remove duplicated and needless id fields 

### DIFF
--- a/hashira-web/src/AccessToken.tsx
+++ b/hashira-web/src/AccessToken.tsx
@@ -58,13 +58,12 @@ const AccessToken: React.FC<{ user: firebase.User | null | undefined }> = ({
             return (
               <li key={token}>
                 <input
-                  id={token}
                   type="checkbox"
                   checked={checkedTokens[token] || false}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                     setCheckedTokens({
                       ...checkedTokens,
-                      [e.target.id]: e.target.checked,
+                      [token]: e.target.checked,
                     });
                   }}
                   name={token}

--- a/hashira-web/src/AccessToken.tsx
+++ b/hashira-web/src/AccessToken.tsx
@@ -56,7 +56,7 @@ const AccessToken: React.FC<{ user: firebase.User | null | undefined }> = ({
           </button>
           {accesstokens.map((token: string) => {
             return (
-              <li key={token}>
+              <li key={token} data-accesstoken={token}>
                 <input
                   type="checkbox"
                   checked={checkedTokens[token] || false}

--- a/hashira-web/src/TaskList.tsx
+++ b/hashira-web/src/TaskList.tsx
@@ -126,7 +126,7 @@ export const TaskList: React.VFC<{
       const taskId = tasksAndPriorities["Tasks"][p].ID;
       const taskName = tasksAndPriorities["Tasks"][p].Name;
       return (
-        <StyledListItem key={taskId} data-taskId={taskId}>
+        <StyledListItem key={taskId} data-tasktoken={taskId}>
           <>
             <StyledListContent
               style={{

--- a/hashira-web/src/TaskList.tsx
+++ b/hashira-web/src/TaskList.tsx
@@ -126,13 +126,12 @@ export const TaskList: React.VFC<{
       const taskId = tasksAndPriorities["Tasks"][p].ID;
       const taskName = tasksAndPriorities["Tasks"][p].Name;
       return (
-        <StyledListItem key={taskId}>
+        <StyledListItem key={taskId} data-taskId={taskId}>
           <>
             <StyledListContent
               style={{
                 marginRight: mode === "select" ? "0px" : "24px",
               }}
-              id={taskId}
               key={taskId}
               value={updatedTasks[taskId] !== undefined
                 ? updatedTasks[taskId]
@@ -140,7 +139,7 @@ export const TaskList: React.VFC<{
               onChange={(e) => {
                 setUpdatedTasks({
                   ...updatedTasks,
-                  [e.target.id]: e.target.value,
+                  [taskId]: e.target.value,
                 });
               }}
               onBlur={() => onEditCompleted()}
@@ -149,12 +148,11 @@ export const TaskList: React.VFC<{
             {mode === "select"
               ? (
                 <StyledCheckbox
-                  id={taskId}
                   value={taskName}
                   onChange={(e) => {
                     setCheckedTasks({
                       ...checkedTasks,
-                      [e.target.id]: e.target.checked,
+                      [taskId]: e.target.checked,
                     });
                   }}
                 />
@@ -162,16 +160,14 @@ export const TaskList: React.VFC<{
               : (
                 <StyledArrow>
                   <div
-                    id={taskId}
                     style={{ cursor: "pointer" }}
-                    onClick={(e) => onMoveTask(e.currentTarget.id, "left")}
+                    onClick={(e) => onMoveTask(taskId, "left")}
                   >
                     👈
                   </div>
                   <div
-                    id={taskId}
                     style={{ cursor: "pointer" }}
-                    onClick={(e) => onMoveTask(e.currentTarget.id, "right")}
+                    onClick={(e) => onMoveTask(taskId, "right")}
                   >
                     👉
                   </div>


### PR DESCRIPTION
React provides `useId` hook, but we don't need it this time. We can handle on* events without ID property.
But I keep `data-taskId` in container.
Because it helps our debug in browser console

Fixes #873