### PR TITLE
Refactor duplicate and temporary named updateTask* methods

### DIFF
--- a/hashira-web/src/App.tsx
+++ b/hashira-web/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from "react";
 import styled from "styled-components";
 import * as firebase from "./firebase";
 import Header from "./Header";
-import { useAddTasks, useFetchTasksAndPriorities, useUpdateTasks, useUpdateTasks2 } from "./hooks";
+import { useAddTasks, useFetchTasksAndPriorities, useUpdateTasks } from "./hooks";
 import { StyledHorizontalSpacer, StyledVerticalSpacer } from "./styles";
 import TaskInput from "./TaskInput";
 import { TaskList } from "./TaskList";
@@ -22,13 +22,11 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
 
   const [addTasksState, addTasks] = useAddTasks();
   const [updateTasksState, updateTasks] = useUpdateTasks();
-  const [updateTasks2State, updateTasks2] = useUpdateTasks2();
   const [fetchTasksAndPrioritiesState, fetchTasksAndPriorities] = useFetchTasksAndPriorities();
 
   const tasksAndPriorities = fetchTasksAndPrioritiesState.data;
   const isLoading = addTasksState.isLoading
     || updateTasksState.isLoading
-    || updateTasks2State.isLoading
     || fetchTasksAndPrioritiesState.isLoading;
 
   const onSubmitTasks = React.useCallback(
@@ -87,7 +85,7 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
 
         try {
           isMoveTaskProcessing.current = true;
-          await updateTasks(tasksToMove);
+          await updateTasks(tasksToMove, true);
           await fetchTasksAndPriorities(user.uid);
           resolve();
         } catch (e) {
@@ -108,7 +106,7 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
           return;
         }
         try {
-          await updateTasks2(tasks);
+          await updateTasks(tasks, false);
           // refresh tasks and priorities
           await fetchTasksAndPriorities(user.uid);
           resolve();
@@ -196,7 +194,7 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
                       }
                     }
 
-                    await updateTasks(tasksToMarkAsDone);
+                    await updateTasks(tasksToMarkAsDone, true);
                     // refresh tasks and priorities
                     await fetchTasksAndPriorities(user.uid);
                     setCheckedTasks({});

--- a/hashira-web/src/firebase.ts
+++ b/hashira-web/src/firebase.ts
@@ -162,10 +162,7 @@ export interface TasksObject {
   };
 }
 
-// updateTasks
-// task の状態を変えるために用いる。変更があった task はそれぞれのレーンの一番上に積まれる。
-// もっぱら、タスクの状態を変更する (横移動する) ために用いる。
-export const updateTasks = async (tasksObject: TasksObject) => {
+const newPriorities = (tasksObject: TasksObject) => {
   const priorities: {
     [key in typeof Places[number]]: string[];
   } = {
@@ -179,33 +176,24 @@ export const updateTasks = async (tasksObject: TasksObject) => {
     priorities[task.Place].push(task.ID);
   }
 
-  try {
-    await functions.httpsCallable(
-      functions.getFunctions(undefined, "asia-northeast1"),
-      "call?method=add",
-    )({
-      tasks: tasksObject,
-      priority: priorities,
-    });
-  } catch (e) {
-    // FIXME:
-    // currently cloud functions doesn't return appropriate response
-    // that fits httpsCallable protocol even if the function succeeded.
-    console.log("error:", e);
-  }
+  return priorities;
 };
 
-// updateTasks2
-// task の状態を変更するために用いる。変更があった task の場所はそのまま維持される。
-// もっぱら、task の中身を編集するときに用いられる。
-// FIXME: 名前がひどいので直すこと
-export const updateTasks2 = async (tasksObject: TasksObject) => {
+// updateTasks
+//
+// @param updatePosition - Stack the updated tasks on top of each lane if true
+export const updateTasks = async (tasksObject: TasksObject, updatePosition: boolean) => {
+  const appendix = updatePosition
+    ? { priority: newPriorities(tasksObject) }
+    : {};
+
   try {
     await functions.httpsCallable(
       functions.getFunctions(undefined, "asia-northeast1"),
       "call?method=add",
     )({
       tasks: tasksObject,
+      ...appendix,
     });
   } catch (e) {
     // FIXME:

--- a/hashira-web/src/hooks.ts
+++ b/hashira-web/src/hooks.ts
@@ -47,7 +47,7 @@ export const useAddTasks = (): [
 
 export const useUpdateTasks = (): [
   APIState<void>,
-  (tasks: firebase.TasksObject) => Promise<void>,
+  (tasks: firebase.TasksObject, updatePosition: boolean) => Promise<void>,
 ] => {
   const [state, setState] = React.useState<APIState<void>>({
     isLoading: false,
@@ -57,7 +57,7 @@ export const useUpdateTasks = (): [
 
   return [
     state,
-    React.useCallback((tasks: firebase.TasksObject): Promise<void> => {
+    React.useCallback((tasks: firebase.TasksObject, updatePosition: boolean): Promise<void> => {
       return new Promise<void>((resolve, reject) => {
         setState({
           isLoading: true,
@@ -66,43 +66,7 @@ export const useUpdateTasks = (): [
         });
 
         firebase
-          .updateTasks(tasks)
-          .then((result) => {
-            setState({
-              isLoading: false,
-              error: null,
-              data: result,
-            });
-            resolve(result);
-          })
-          .catch((e) => reject(e));
-      });
-    }, []),
-  ];
-};
-
-export const useUpdateTasks2 = (): [
-  APIState<void>,
-  (tasks: firebase.TasksObject) => Promise<void>,
-] => {
-  const [state, setState] = React.useState<APIState<void>>({
-    isLoading: false,
-    error: null,
-    data: null,
-  });
-
-  return [
-    state,
-    React.useCallback((tasks: firebase.TasksObject): Promise<void> => {
-      return new Promise<void>((resolve, reject) => {
-        setState({
-          isLoading: true,
-          error: null,
-          data: null,
-        });
-
-        firebase
-          .updateTasks2(tasks)
+          .updateTasks(tasks, updatePosition)
           .then((result) => {
             setState({
               isLoading: false,


### PR DESCRIPTION
I think unnecessary to have 2 methods. Because the role is just duplicated.