### PR TITLE
Remove deprecated functions

### DIFF
--- a/hashira-web/functions/Makefile
+++ b/hashira-web/functions/Makefile
@@ -1,32 +1,5 @@
 test:
 	go test ./...
 
-deploy-all:
-	make deploy-call
-	make deploy-ping
-	make deploy-upload
-	make deploy-download
-	make deploy-test-access-token
-
 deploy-call:
 	gcloud functions deploy call --entry-point Call --runtime go116 --memory 256MB --trigger-http --allow-unauthenticated --region asia-northeast1 --max-instances 10
-
-# deprecated
-deploy-ping:
-	gcloud functions deploy ping --entry-point Ping --runtime go116 --memory 256MB --trigger-http --allow-unauthenticated --region asia-northeast1 --max-instances 10
-
-# deprecated
-deploy-upload:
-	gcloud functions deploy upload --entry-point Upload --runtime go116 --memory 256MB --trigger-http --allow-unauthenticated --region asia-northeast1 --max-instances 10
-
-# deprecated
-deploy-download:
-	gcloud functions deploy download --entry-point Download --runtime go116 --memory 256MB --trigger-http --allow-unauthenticated --region asia-northeast1 --max-instances 10
-
-# deprecated
-deploy-add:
-	gcloud functions deploy add --entry-point Add --runtime go116 --memory 256MB --trigger-http --allow-unauthenticated --region asia-northeast1 --max-instances 10
-
-# deprecated
-deploy-test-access-token:
-	gcloud functions deploy test-access-token --entry-point TestAccessToken --runtime go116 --memory 256MB --trigger-http --allow-unauthenticated --region asia-northeast1 --max-instances 10

--- a/hashira-web/functions/func.go
+++ b/hashira-web/functions/func.go
@@ -63,64 +63,6 @@ func Call(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// deprecated. use Call instead.
-func Ping(w http.ResponseWriter, r *http.Request) {
-	setHeadersForCORS(w)
-	if r.Method == http.MethodOptions {
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write([]byte("pong")); err != nil {
-		log.Printf("ping failed: %v", err)
-	}
-}
-
-// deprecated. use Call instead.
-func TestAccessToken(w http.ResponseWriter, r *http.Request) {
-	setHeadersForCORS(w)
-	if r.Method == http.MethodOptions {
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-	h := hashira.New(store.NewAccessTokenStore(), store.NewTaskAndPriorityStore())
-	h.TestAccessToken(w, r)
-}
-
-// deprecated. use Call instead.
-func Upload(w http.ResponseWriter, r *http.Request) {
-	setHeadersForCORS(w)
-	if r.Method == http.MethodOptions {
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-	h := hashira.New(store.NewAccessTokenStore(), store.NewTaskAndPriorityStore())
-	h.Upload(w, r)
-}
-
-// deprecated. use Call instead.
-func Download(w http.ResponseWriter, r *http.Request) {
-	setHeadersForCORS(w)
-	if r.Method == http.MethodOptions {
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-	h := hashira.New(store.NewAccessTokenStore(), store.NewTaskAndPriorityStore())
-	h.Download(w, r)
-}
-
-// deprecated. use Call instead.
-func Add(w http.ResponseWriter, r *http.Request) {
-	setHeadersForCORS(w)
-	if r.Method == http.MethodOptions {
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
-	h := hashira.New(store.NewAccessTokenStore(), store.NewTaskAndPriorityStore())
-	h.Add(w, r)
-}
-
 func setHeadersForCORS(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "POST")

--- a/hashira-web/src/firebase.ts
+++ b/hashira-web/src/firebase.ts
@@ -111,9 +111,8 @@ export const revokeAccessTokens = async (
 
 export const Places = ["BACKLOG", "TODO", "DOING", "DONE"] as const;
 
-// uploadTasks
 // 複数の task を受け取って、全部 BACKLOG の一番上に積む
-export const uploadTasks = async (tasks: string[]) => {
+export const addTasks = async (tasks: string[]) => {
   const tasksObject: {
     [key: string]: {
       ID: string;

--- a/hashira-web/src/hooks.ts
+++ b/hashira-web/src/hooks.ts
@@ -30,7 +30,7 @@ export const useAddTasks = (): [
         });
 
         firebase
-          .uploadTasks(normalizeTasks(tasksToAdd))
+          .addTasks(normalizeTasks(tasksToAdd))
           .then(() => {
             setState({
               isLoading: false,


### PR DESCRIPTION
Preparation part of #877 

There is a lot of deprecated code around cloud functions.
Looks like a squashed to an endpoint with a `method' param.