### PR TITLE
Bump dprint config with old dprint binary

### DIFF
--- a/.github/workflows/dprint.yml
+++ b/.github/workflows/dprint.yml
@@ -11,3 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dprint/check@v2.2
+        with:
+          # https://github.com/dprint/dprint-plugin-prettier/issues/56
+          dprint-version: "0.40.1"

--- a/dprint.json
+++ b/dprint.json
@@ -16,9 +16,9 @@
     "docsrc"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.85.0.wasm",
+    "https://plugins.dprint.dev/typescript-0.85.1.wasm",
     "https://plugins.dprint.dev/json-0.17.4.wasm",
     "https://plugins.dprint.dev/markdown-0.15.3.wasm",
-    "https://plugins.dprint.dev/prettier-0.24.0.json@9a57d0d8e440ad90d07a503166af47e7a6a886abd46767933f9c279f72468596"
+    "https://plugins.dprint.dev/prettier-0.27.0.json@3557a62b4507c55a47d8cde0683195b14d13c41dda66d0f0b0e111aed107e2fe"
   ]
 }


### PR DESCRIPTION
```console
> rtx exec dprint@0.39.1 -- dprint config update --yes
> rtx exec dprint@latest -- dprint check
> rtx ls dprint | tail -1
dprint 0.40.1
```

## Pull request for issue #{issue number}

Fixes #935 

After merged this PR, #931, #932, #933, #934 should be rebased

## Updates

- https://github.com/pankona/hashira/pull/871
