### PR TITLE
Automatically merge dependabot PRs with GitHub Actions

### DIFF
--- a/.github/workflows/merge-bot-pr.yml
+++ b/.github/workflows/merge-bot-pr.yml
@@ -1,0 +1,26 @@
+name: Merge bot PR after CI
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+      - name: Wait other jobs
+        # if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
+        uses: kachick/wait-other-jobs@v2
+        timeout-minutes: 15
+      - name: Approve and merge
+        # if: ${{steps.metadata.outputs.update-type != 'version-update:semver-major'}}
+        run: gh pr review --approve "$PR_URL" && gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Resolves #1167

マージ前に以下を有効にしてください

https://github.com/pankona/hashira/settings => Allow auto-merge

```bash
gh repo edit pankona/hashira --enable-auto-merge
```

https://github.com/pankona/hashira/settings/actions => Allow GitHub Actions to create and approve pull requests

```bash
gh api \
  --method PUT \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  /repos/pankona/hashira/actions/permissions/workflow \
  -f default_workflow_permissions='write' \
 -F can_approve_pull_request_reviews=true
```

default_workflow_permissions は action 定義を dependabot が挙げてくるような時に影響しそうな気が・・・？ここは read のままでも動くかも

---

https://github.com/pankona/pankona.github.com/pull/151 同様のやり方でとりあえずPRを出しておきます！
とりあえず GITHUB_TOKEN を使ってるので、これによる マージ後の master では CI が走らなくなります。解消したければなんぞ APP を install して、そいつの PAT 的な token から 使い捨てトークンを発行・・・みたいなのが必要になります。別に難しくはないんですが、Appのインストールとシークレットの登録ステップが面倒ではある＆それをやるのにリポジトリへのフルアクセスが必要だと思うので適宜おまかせしやす。

例

- 発行: https://github.com/kachick/selfup/blob/749c4cbd8f02cec50f27a91aa603c2627d194583/.github/workflows/reusable-bump-flake-lock-and-selfup.yml#L46-L53
- 使う: https://github.com/kachick/selfup/blob/749c4cbd8f02cec50f27a91aa603c2627d194583/.github/workflows/reusable-bump-flake-lock-and-selfup.yml#L97

雑にやるなら自分のPATを貼っても動きます。