### PR TITLE
refactor: remove deprecated functions from Makefile

### DIFF
--- a/hashira-web/functions/Makefile
+++ b/hashira-web/functions/Makefile
@@ -3,30 +3,6 @@ test:
 
 deploy-all:
 	make deploy-call
-	make deploy-ping
-	make deploy-upload
-	make deploy-download
-	make deploy-test-access-token
 
 deploy-call:
-	gcloud functions deploy call --entry-point Call --runtime go120 --memory 256MB --trigger-http --allow-unauthenticated --region asia-northeast1 --max-instances 10
-
-# deprecated
-deploy-ping:
-	gcloud functions deploy ping --entry-point Ping --runtime go120 --memory 256MB --trigger-http --allow-unauthenticated --region asia-northeast1 --max-instances 10
-
-# deprecated
-deploy-upload:
-	gcloud functions deploy upload --entry-point Upload --runtime go120 --memory 256MB --trigger-http --allow-unauthenticated --region asia-northeast1 --max-instances 10
-
-# deprecated
-deploy-download:
-	gcloud functions deploy download --entry-point Download --runtime go120 --memory 256MB --trigger-http --allow-unauthenticated --region asia-northeast1 --max-instances 10
-
-# deprecated
-deploy-add:
-	gcloud functions deploy add --entry-point Add --runtime go120 --memory 256MB --trigger-http --allow-unauthenticated --region asia-northeast1 --max-instances 10
-
-# deprecated
-deploy-test-access-token:
-	gcloud functions deploy test-access-token --entry-point TestAccessToken --runtime go120 --memory 256MB --trigger-http --allow-unauthenticated --region asia-northeast1 --max-instances 10
+	gcloud functions deploy call --gen2 --entry-point Call --runtime go122 --memory 256Mi --trigger-http --allow-unauthenticated --region asia-northeast1 --max-instances 10


### PR DESCRIPTION
- 非推奨（deprecated）な関数のデプロイコマンドを削除
- deploy-allターゲットを簡素化
- callのみを2nd gen対応で維持