### PR TITLE
Update frontend to support multiple word filters

### DIFF
--- a/hashira-web/src/App.tsx
+++ b/hashira-web/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from "react";
 import styled from "styled-components";
 import * as firebase from "./firebase";
 import Header from "./Header";
-import { useAddTasks, useFetchTasksAndPriorities, useUpdateTasks } from "./hooks";
+import { useAddTasks, useFetchTasksAndPriorities, useUpdateTasks, useFilteredTasks } from "./hooks";
 import { StyledHorizontalSpacer, StyledVerticalSpacer } from "./styles";
 import TaskInput from "./TaskInput";
 import { TaskList } from "./TaskList";
@@ -19,6 +19,7 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
     [key: string]: boolean;
   }>({});
   const [mode, setMode] = React.useState<"move" | "select">("select");
+  const [filter, setFilter] = React.useState<string>("");
 
   const [addTasksState, addTasks] = useAddTasks();
   const [updateTasksState, updateTasks] = useUpdateTasks();
@@ -28,6 +29,8 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
   const isLoading = addTasksState.isLoading
     || updateTasksState.isLoading
     || fetchTasksAndPrioritiesState.isLoading;
+
+  const filteredTasks = useFilteredTasks(tasksAndPriorities ? tasksAndPriorities.Tasks : [], filter);
 
   const onSubmitTasks = React.useCallback(
     (tasks: string[]) => {
@@ -218,6 +221,13 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
                 />
               </div>
               <StyledVerticalSpacer />
+              <input
+                type="text"
+                placeholder="Filter tasks"
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+              />
+              <StyledVerticalSpacer />
               {tasksAndPriorities
                 ? (
                   <div
@@ -229,7 +239,7 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
                   >
                     <TaskList
                       place={"BACKLOG"}
-                      tasksAndPriorities={tasksAndPriorities}
+                      tasksAndPriorities={{ ...tasksAndPriorities, Tasks: filteredTasks }}
                       checkedTasks={checkedTasks}
                       setCheckedTasks={setCheckedTasks}
                       onEditTasks={onEditTasks}
@@ -238,7 +248,7 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
                     />
                     <TaskList
                       place={"TODO"}
-                      tasksAndPriorities={tasksAndPriorities}
+                      tasksAndPriorities={{ ...tasksAndPriorities, Tasks: filteredTasks }}
                       checkedTasks={checkedTasks}
                       setCheckedTasks={setCheckedTasks}
                       onEditTasks={onEditTasks}
@@ -247,7 +257,7 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
                     />
                     <TaskList
                       place={"DOING"}
-                      tasksAndPriorities={tasksAndPriorities}
+                      tasksAndPriorities={{ ...tasksAndPriorities, Tasks: filteredTasks }}
                       checkedTasks={checkedTasks}
                       setCheckedTasks={setCheckedTasks}
                       onEditTasks={onEditTasks}
@@ -256,7 +266,7 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
                     />
                     <TaskList
                       place={"DONE"}
-                      tasksAndPriorities={tasksAndPriorities}
+                      tasksAndPriorities={{ ...tasksAndPriorities, Tasks: filteredTasks }}
                       checkedTasks={checkedTasks}
                       setCheckedTasks={setCheckedTasks}
                       onEditTasks={onEditTasks}

--- a/hashira-web/src/App.tsx
+++ b/hashira-web/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from "react";
 import styled from "styled-components";
 import * as firebase from "./firebase";
 import Header from "./Header";
-import { useAddTasks, useFetchTasksAndPriorities, useUpdateTasks, useFilteredTasks } from "./hooks";
+import { useAddTasks, useFetchTasksAndPriorities, useFilteredTasks, useUpdateTasks } from "./hooks";
 import { StyledHorizontalSpacer, StyledVerticalSpacer } from "./styles";
 import TaskInput from "./TaskInput";
 import { TaskList } from "./TaskList";
@@ -150,6 +150,7 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
           <TaskInput
             onSubmitTasks={onSubmitTasks}
             disabled={isLoading || !user}
+            onFilterChange={setFilter}
           />
         )}
         <StyledVerticalSpacer />
@@ -220,13 +221,6 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
                   }}
                 />
               </div>
-              <StyledVerticalSpacer />
-              <input
-                type="text"
-                placeholder="Filter tasks"
-                value={filter}
-                onChange={(e) => setFilter(e.target.value)}
-              />
               <StyledVerticalSpacer />
               {tasksAndPriorities
                 ? (

--- a/hashira-web/src/TaskInput.tsx
+++ b/hashira-web/src/TaskInput.tsx
@@ -10,8 +10,10 @@ const StyledInputForm = styled.form`
 const TaskInput: React.FC<{
   onSubmitTasks: (tasks: string[]) => Promise<void>;
   disabled: boolean;
-}> = ({ onSubmitTasks, disabled }) => {
+  onFilterChange: (filter: string) => void;
+}> = ({ onSubmitTasks, disabled, onFilterChange }) => {
   const [tasks, setTasks] = React.useState<string[]>([]);
+  const [filter, setFilter] = React.useState<string>("");
 
   return (
     <StyledInputForm>
@@ -34,6 +36,16 @@ const TaskInput: React.FC<{
           e.preventDefault();
           await onSubmitTasks(tasks);
           setTasks([]);
+        }}
+      />
+      <StyledHorizontalSpacer />
+      <input
+        type="text"
+        placeholder="Filter tasks"
+        value={filter}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          setFilter(e.target.value);
+          onFilterChange(e.target.value);
         }}
       />
     </StyledInputForm>

--- a/hashira-web/src/hooks.ts
+++ b/hashira-web/src/hooks.ts
@@ -195,3 +195,15 @@ export const useUser = () => {
 
   return state;
 };
+
+export const useFilteredTasks = (tasks: any, filter: string): any => {
+  return React.useMemo(() => {
+    if (!filter) return tasks;
+
+    const filterWords = filter.split(" ").map(word => word.toLowerCase());
+
+    return tasks.filter((task: any) => {
+      return filterWords.every(word => task.name.toLowerCase().includes(word));
+    });
+  }, [tasks, filter]);
+};


### PR DESCRIPTION
Add support for filtering tasks with multiple words separated by spaces and treating them as AND conditions.

* **hooks.ts**: Add a new hook `useFilteredTasks` to filter tasks based on multiple words.
* **App.tsx**: Import and use the new `useFilteredTasks` hook for filtering tasks. Add a filter input field and update the task display logic to show filtered tasks based on multiple words.
* **TaskInput.tsx**: Update the task input handling to support multiple word filters and pass them to the `useFilteredTasks` hook. Add a filter input field.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pankona/hashira/pull/1305?shareId=61eced6e-ca76-4d82-8820-84a60904b8b3).