### PR TITLE
feat: add task filter with browser persistence

### DIFF
--- a/hashira-web/src/App.tsx
+++ b/hashira-web/src/App.tsx
@@ -19,6 +19,15 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
     [key: string]: boolean;
   }>({});
   const [mode, setMode] = React.useState<"move" | "select">("select");
+  const [filterText, setFilterText] = React.useState<string>(() => {
+    const savedFilter = localStorage.getItem("hashira-filter-text");
+    return savedFilter || "";
+  });
+
+  // フィルターテキストが変更されたときにローカルストレージに保存
+  React.useEffect(() => {
+    localStorage.setItem("hashira-filter-text", filterText);
+  }, [filterText]);
 
   const [addTasksState, addTasks] = useAddTasks();
   const [updateTasksState, updateTasks] = useUpdateTasks();
@@ -144,10 +153,23 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
       <Header user={user} />
       <StyledBody>
         {user !== null && (
-          <TaskInput
-            onSubmitTasks={onSubmitTasks}
-            disabled={isLoading || !user}
-          />
+          <>
+            <div style={{ display: "flex", alignItems: "center" }}>
+              <TaskInput
+                onSubmitTasks={onSubmitTasks}
+                disabled={isLoading || !user}
+              />
+              <StyledHorizontalSpacer />
+              <input
+                type="text"
+                placeholder="Filter tasks..."
+                value={filterText}
+                onChange={(e) => setFilterText(e.target.value)}
+                style={{ minWidth: "200px", height: "24px" }}
+              />
+            </div>
+            <StyledVerticalSpacer />
+          </>
         )}
         <StyledVerticalSpacer />
         {(() => {
@@ -235,6 +257,7 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
                       onEditTasks={onEditTasks}
                       mode={mode}
                       onMoveTask={onMoveTask}
+                      filterText={filterText}
                     />
                     <TaskList
                       place={"TODO"}
@@ -244,6 +267,7 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
                       onEditTasks={onEditTasks}
                       mode={mode}
                       onMoveTask={onMoveTask}
+                      filterText={filterText}
                     />
                     <TaskList
                       place={"DOING"}
@@ -253,6 +277,7 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
                       onEditTasks={onEditTasks}
                       mode={mode}
                       onMoveTask={onMoveTask}
+                      filterText={filterText}
                     />
                     <TaskList
                       place={"DONE"}
@@ -262,6 +287,7 @@ const App: React.FC<{ user: firebase.User | null | undefined }> = ({
                       onEditTasks={onEditTasks}
                       mode={mode}
                       onMoveTask={onMoveTask}
+                      filterText={filterText}
                     />
                   </div>
                 )

--- a/hashira-web/src/TaskList.tsx
+++ b/hashira-web/src/TaskList.tsx
@@ -59,6 +59,7 @@ export const TaskList: React.FC<{
   onEditTasks: (tasks: firebase.TasksObject) => Promise<void>;
   mode: "move" | "select";
   onMoveTask: (taskId: string, direction: "left" | "right") => Promise<void>;
+  filterText: string;
 }> = ({
   place,
   tasksAndPriorities,
@@ -67,6 +68,7 @@ export const TaskList: React.FC<{
   onEditTasks,
   mode,
   onMoveTask,
+  filterText,
 }) => {
   const [updatedTasks, setUpdatedTasks] = React.useState<{
     [key: string]: string;
@@ -115,9 +117,16 @@ export const TaskList: React.FC<{
     if (!tasksAndPriorities["Priority"][place]) {
       return noItem;
     }
-    const filteredItems = tasksAndPriorities["Priority"][place].filter(
-      (v: string) => tasksAndPriorities["Tasks"][v],
-    );
+    const filteredItems = tasksAndPriorities["Priority"][place]
+      .filter((v: string) => tasksAndPriorities["Tasks"][v])
+      .filter((v: string) => {
+        if (!filterText) return true;
+        const taskName = tasksAndPriorities["Tasks"][v].Name.toLowerCase();
+        return filterText.toLowerCase().split(" ").every(word => 
+          taskName.includes(word.trim())
+        );
+      });
+
     if (filteredItems.length === 0) {
       return noItem;
     }

--- a/hashira-web/src/TaskList.tsx
+++ b/hashira-web/src/TaskList.tsx
@@ -122,9 +122,7 @@ export const TaskList: React.FC<{
       .filter((v: string) => {
         if (!filterText) return true;
         const taskName = tasksAndPriorities["Tasks"][v].Name.toLowerCase();
-        return filterText.toLowerCase().split(" ").every(word => 
-          taskName.includes(word.trim())
-        );
+        return filterText.toLowerCase().split(" ").every(word => taskName.includes(word.trim()));
       });
 
     if (filteredItems.length === 0) {


### PR DESCRIPTION
タスク一覧の視認性を向上させるためのフィルター機能を追加: (1) Add Todos 入力欄の右側にフィルター用の入力欄を追加 (2) スペース区切りで複数のワードを指定可能（AND条件） (3) インクリメンタルなフィルタリング (4) フィルターの状態をブラウザのローカルストレージに保存 (5) ページ読み込み時に状態を復元