### PR TITLE
Fix failing golangci-lint in CI

### DIFF
--- a/.github/workflows/hashira-cui--test.yml
+++ b/.github/workflows/hashira-cui--test.yml
@@ -41,6 +41,6 @@ jobs:
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@818ec4d51a1feacefc42ff1b3ec25d4962690f39 # v6.4.1
         with:
           version: v1.63.4

--- a/.github/workflows/hashira-cui--test.yml
+++ b/.github/workflows/hashira-cui--test.yml
@@ -41,6 +41,6 @@ jobs:
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"
-      - uses: golangci/golangci-lint-action@818ec4d51a1feacefc42ff1b3ec25d4962690f39 # v6.4.1
+      - uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
         with:
           version: v1.63.4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
-skip-dirs:
-  - service
-  - hashira-web/
+issues:
+  exclude-dirs:
+    - service
+    - hashira-web/


### PR DESCRIPTION
https://github.com/pankona/hashira/pull/1287 以降 golangci-lint でCIが落ちている

```
jsonschema: "" does not validate with "/additionalProperties": additional properties 'skip-dirs' not allowed
Failed executing command with error: the configuration contains invalid elements
, Error: Command failed: /home/runner/golangci-lint-1.63.4-linux-amd64/golangci-lint config verify
jsonschema: "" does not validate with "/additionalProperties": additional properties 'skip-dirs' not allowed
Failed executing command with error: the configuration contains invalid elements
```

ログとか upstream の更新状況を見る限り https://github.com/golangci/golangci-lint-action/releases/tag/v6.5.0 で verify option がデフォルトで有効にされたため、もともと壊れていたが気付けなかった config schema の古さから落ちるようになったと思われる

https://github.com/golangci/golangci-lint-action/pull/1171

通ってたとき

```yaml
Run golangci/golangci-lint-action@v6
  with:
    version: v1.6[3](https://github.com/pankona/hashira/actions/runs/12844075664/job/35816704431#step:4:3).4
    install-mode: binary
    github-token: ***
    only-new-issues: false
    skip-cache: false
    skip-save-cache: false
    problem-matchers: false
    cache-invalidation-interval: [7](https://github.com/pankona/hashira/actions/runs/12844075664/job/35816704431#step:4:7)
```

落ちるようになってから

```yaml
Run golangci/golangci-lint-action@v6
  with:
    version: v1.6[3](https://github.com/pankona/hashira/actions/runs/14202665657/job/39793024992#step:4:3).4
    install-mode: binary
    github-token: ***
    verify: true
    only-new-issues: false
    skip-cache: false
    skip-save-cache: false
    problem-matchers: false
    cache-invalidation-interval: [7](https://github.com/pankona/hashira/actions/runs/14202665657/job/39793024992#step:4:7)
```

https://github.com/golangci/golangci-lint/blob/544018f712a7506c49ecdb75b8cb5a4e7bbb7534/docs/src/docs/product/migration-guide.mdx#runskip-dirs みたいな変更をかければ直ると思うけれど、再現性が無いとどちらにせよキツイのでまず GHA のバージョンであることの確認後に今後は該当アクションのメジャーバージョンかつタグのみ利用を避ける。そんで config 更新して通れば滞留している dependabot PRs をマージしてヨシとする