### PR TITLE
Bump golangci-lint to v2.x

### DIFF
--- a/.github/workflows/hashira-cui--test.yml
+++ b/.github/workflows/hashira-cui--test.yml
@@ -43,4 +43,4 @@ jobs:
           cache-dependency-path: "go.sum"
       - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.63.4
+          version: v2.0.2

--- a/.github/workflows/hashira-cui--test.yml
+++ b/.github/workflows/hashira-cui--test.yml
@@ -41,6 +41,6 @@ jobs:
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"
-      - uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+      - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           version: v1.63.4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,22 @@
-issues:
-  exclude-dirs:
-    - service
-    - hashira-web/
+version: "2"
+linters:
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - service
+      - hashira-web/
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/sync/client.go
+++ b/sync/client.go
@@ -36,7 +36,7 @@ func (c *Client) TestAccessToken(accesstoken string) error {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("This accesstoken is not valid. Please check HASHIRA_ACCESS_TOKEN is correct and try again [%d].", resp.StatusCode)
+		return fmt.Errorf("this accesstoken is not valid. Please check HASHIRA_ACCESS_TOKEN is correct and try again [%d]", resp.StatusCode)
 	}
 
 	return nil


### PR DESCRIPTION
https://github.com/pankona/hashira/pull/1330 で golangci-lint が cli-v1 系ですら落ちているのは直した
しかし世はすでに cli-v2 時代らしく、 https://github.com/pankona/hashira/pull/1327 みたいに action-v7 以降は cli-v1 をサポートしないらしい

ということで更新してみました。殆どツールが持ってる migration 機能と、その後に出してきたエラーを言われるがまま潰しただけです。