### PR TITLE
feat: improve hashira CLI list command with filter support

### DIFF
--- a/cmd/hashira/commands.go
+++ b/cmd/hashira/commands.go
@@ -55,9 +55,12 @@ func list(ctx context.Context, c *client.Client, filter string) error {
 		return fmt.Errorf("failed to retrieve tasks: %v", err)
 	}
 	
+	// Normalize filter once before the loop for better performance
+	normalizedFilter := strings.ToLower(filter)
+	
 	filteredTasks := make(map[string]*service.Task)
 	for k, v := range tasks {
-		if filter == "" || strings.Contains(strings.ToLower(v.Name), strings.ToLower(filter)) {
+		if normalizedFilter == "" || strings.Contains(strings.ToLower(v.Name), normalizedFilter) {
 			filteredTasks[k] = v
 		}
 	}

--- a/cmd/hashira/commands.go
+++ b/cmd/hashira/commands.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
+	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/pankona/hashira/client"
@@ -28,8 +28,12 @@ func addListCmd(ctx context.Context, c *client.Client) {
 	listCmd := kingpin.Command(
 		"list",
 		"show list of tasks")
+	filter := listCmd.Flag(
+		"filter",
+		"filter tasks by name (case-insensitive substring match)").
+		String()
 	_ = listCmd.Action(func(pc *kingpin.ParseContext) error {
-		return list(ctx, c)
+		return list(ctx, c, *filter)
 	})
 }
 
@@ -45,17 +49,30 @@ func create(ctx context.Context, c *client.Client, name string) error {
 	return nil
 }
 
-func list(ctx context.Context, c *client.Client) error {
+func list(ctx context.Context, c *client.Client, filter string) error {
 	tasks, err := c.Retrieve(ctx)
 	if err != nil {
-		return errors.New("failed to create a new task: " + err.Error())
+		return fmt.Errorf("failed to retrieve tasks: %v", err)
 	}
-	for _, v := range tasks {
-		id, err := strconv.Atoi(v.Id)
-		if err != nil {
-			continue
+	
+	filteredTasks := make(map[string]*service.Task)
+	for k, v := range tasks {
+		if filter == "" || strings.Contains(strings.ToLower(v.Name), strings.ToLower(filter)) {
+			filteredTasks[k] = v
 		}
-		fmt.Printf("[%04d]\t%s\t%v\t%v\n", id, v.Name, v.Place, v.IsDeleted)
+	}
+	
+	if len(filteredTasks) == 0 {
+		if filter != "" {
+			fmt.Printf("No tasks found matching filter: %s\n", filter)
+		} else {
+			fmt.Println("No tasks found.")
+		}
+		return nil
+	}
+	
+	for _, v := range filteredTasks {
+		fmt.Printf("[%s]\t%s\t%v\t%v\n", v.Id, v.Name, v.Place, v.IsDeleted)
 	}
 	return nil
 }

--- a/cmd/hashira/main.go
+++ b/cmd/hashira/main.go
@@ -14,7 +14,7 @@ const (
 
 func main() {
 	c := &client.Client{
-		Address: "localhost:50056",
+		Address: "localhost:50057",
 	}
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary
- Fix list command to display tasks properly with UUID format instead of skipping them
- Add --filter flag for case-insensitive substring matching on task names  
- Update server port from 50056 to 50057 to match daemon configuration

## Changes
- `cmd/hashira/main.go`: Update client port to 50057
- `cmd/hashira/commands.go`: 
  - Add --filter flag to list command
  - Implement filtering logic with case-insensitive substring matching
  - Replace integer ID parsing with direct UUID display
  - Add appropriate messages for empty and filtered results

## Test plan
- [x] Verify list command displays all tasks with UUID format
- [x] Test --filter flag with existing task names (e.g., "book")
- [x] Test --filter flag with non-existent terms shows appropriate message
- [x] Confirm client connects to correct port (50057)

🤖 Generated with [Claude Code](https://claude.ai/code)