### PR TITLE
feat: add automatic daemon startup and lint tool installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,15 @@ update-dependencies:
 	cd $(CURDIR)/cmd/hashira-cui         && $(UPDATE_DEPENDENCIES_CMD)
 	cd $(CURDIR)/cmd/hashira-web-client  && $(UPDATE_DEPENDENCIES_CMD)
 
-lint:
-	dprint check
+lint: install-dprint install-golangci-lint
+	@PATH="$$HOME/.dprint/bin:$$PATH" dprint check
 	golangci-lint run ./...
+
+install-dprint:
+	@which dprint > /dev/null || PATH="$$HOME/.dprint/bin:$$PATH" which dprint > /dev/null || (echo "Installing dprint..." && curl -fsSL https://dprint.dev/install.sh | sh)
+
+install-golangci-lint:
+	@which golangci-lint > /dev/null || (echo "Installing golangci-lint..." && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin)
 
 test:
 	go test -race ./...


### PR DESCRIPTION
## Summary
- Add automatic daemon startup functionality to hashira CLI
- Implement lint tool auto-installation in Makefile
- Fix various bugs and improve CLI usability

## Changes
- **Daemon Management**: Add automatic daemon startup when CLI commands are executed
- **CLI Improvements**: Add task filtering functionality to list command
- **Lint Tools**: Add auto-installation for dprint and golangci-lint in Makefile
- **Bug Fixes**: Fix cloud functions endpoints and resolve lint errors
- **Refactoring**: Replace go run with direct daemon package usage for single binary

## Test plan
- [x] Verify `make lint` works with auto-installation of tools
- [x] Test daemon auto-startup functionality
- [x] Confirm CLI commands work with new daemon management
- [x] Validate task filtering in list command

🤖 Generated with [Claude Code](https://claude.ai/code)