### PR TITLE
fix: remove pull_request trigger to prevent duplicate job execution

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,8 +3,6 @@ name: Auto format
 on:
   push:
     branches: ["**"]
-  pull_request:
-    branches: ["master", "main"]
 
 permissions:
   contents: write


### PR DESCRIPTION
Only run auto-format on push events to avoid conflicts when PRs are updated

## Pull request for issue #{issue number}

## Updates

-
